### PR TITLE
회원가입 UiState 관련 리펙토링 및 회원가입 에러 표시 기능 추가

### DIFF
--- a/app/src/main/java/com/boosters/promise/data/user/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/boosters/promise/data/user/UserRepositoryImpl.kt
@@ -10,8 +10,8 @@ class UserRepositoryImpl(
 ) : UserRepository {
 
     override suspend fun requestSignUp(userName: String): Result<User> {
-        return userRemoteDataSource.requestSignUp(userName).also {
-            myInfoLocalDataSource.saveMyInfo(it.getOrThrow())
+        return userRemoteDataSource.requestSignUp(userName).onSuccess {
+            myInfoLocalDataSource.saveMyInfo(it)
         }
     }
 

--- a/app/src/main/java/com/boosters/promise/ui/signup/SignUpActivity.kt
+++ b/app/src/main/java/com/boosters/promise/ui/signup/SignUpActivity.kt
@@ -8,6 +8,7 @@ import androidx.activity.viewModels
 import androidx.databinding.DataBindingUtil
 import com.boosters.promise.R
 import com.boosters.promise.databinding.ActivitySignUpBinding
+import com.google.android.material.snackbar.Snackbar
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -32,11 +33,15 @@ class SignUpActivity : AppCompatActivity() {
             signUpViewModel.requestSignUp()
         }
 
-        signUpViewModel.isCompleteSignUp.observe(this) { isCompleteSignUp ->
-            if (isCompleteSignUp) {
+        signUpViewModel.signUpUiState.observe(this) { signUpUiState ->
+            if (signUpUiState.isCompleteSignUp) {
 //                startActivity(Intent(this, PromiseSettingActivity::class.java))
                 // TODO: Home 약속 리스트 화면으로 이동 구현
                 finish()
+            } else {
+                signUpUiState.signUpErrorMessageResId?.let {
+                    Snackbar.make(binding.root, it, Snackbar.LENGTH_SHORT).show()
+                }
             }
         }
     }

--- a/app/src/main/java/com/boosters/promise/ui/signup/SignUpActivity.kt
+++ b/app/src/main/java/com/boosters/promise/ui/signup/SignUpActivity.kt
@@ -11,6 +11,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import com.boosters.promise.R
 import com.boosters.promise.databinding.ActivitySignUpBinding
+import com.boosters.promise.ui.signup.model.SignUpUiState
 import com.google.android.material.snackbar.Snackbar
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
@@ -55,17 +56,21 @@ class SignUpActivity : AppCompatActivity() {
 
         lifecycleScope.launch {
             signUpViewModel.signUpUiState.collect { signUpUiState ->
-                if (signUpUiState.isCompleteSignUp) {
-//                    startActivity(Intent(this@SignUpActivity, PromiseSettingActivity::class.java))
-                    // TODO: Home 약속 리스트 화면으로 이동 구현
-                    finish()
-                } else {
-                    signUpUiState.signUpErrorMessageResId?.let {
-                        Snackbar.make(binding.root, it, Snackbar.LENGTH_SHORT).show()
+                when (signUpUiState) {
+                    is SignUpUiState.Nothing -> binding.isLoading = false
+                    is SignUpUiState.Loading -> binding.isLoading = true
+                    is SignUpUiState.Success -> {
+                        // TODO: Home 약속 리스트 화면으로 이동 구현
+//                    startActivity(Intent(this@SignUpActivity, PromiseSettingActivity::class.java)).also { finish() }
+                        finish()
+                    }
+                    is SignUpUiState.Fail -> {
+                        signUpUiState.signUpErrorMessageResId?.let {
+                            Snackbar.make(binding.root, it, Snackbar.LENGTH_SHORT).show()
+                        }
                     }
                 }
             }
         }
     }
-
 }

--- a/app/src/main/java/com/boosters/promise/ui/signup/SignUpViewModel.kt
+++ b/app/src/main/java/com/boosters/promise/ui/signup/SignUpViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.boosters.promise.R
 import com.boosters.promise.data.user.UserRepository
+import com.boosters.promise.ui.signup.model.NameInputUiState
 import com.boosters.promise.ui.signup.model.SignUpUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
@@ -24,14 +25,19 @@ class SignUpViewModel @Inject constructor(
     private val _isCompleteSignUp = MutableLiveData(false)
     val isCompleteSignUp: LiveData<Boolean> = _isCompleteSignUp
 
+    private val _nameInputUiState = MutableLiveData<NameInputUiState>()
+    val nameInputUiState: LiveData<NameInputUiState> = _nameInputUiState
+
     fun requestSignUp() {
         enterName.value?.let { name ->
             if (nameValidationRegex.matches(name).not()) {
-                _signUpUiState.value = SignUpUiState(
+                _nameInputUiState.value = NameInputUiState(
                     isNameValidationFail = true,
-                    errorText = R.string.signUp_inputError
+                    nameValidationErrorTextResId = R.string.signUp_inputError
                 )
                 return
+            } else {
+                _nameInputUiState.value = NameInputUiState()
             }
             _signUpUiState.value = SignUpUiState(true)
             viewModelScope.launch {

--- a/app/src/main/java/com/boosters/promise/ui/signup/SignUpViewModel.kt
+++ b/app/src/main/java/com/boosters/promise/ui/signup/SignUpViewModel.kt
@@ -22,9 +22,6 @@ class SignUpViewModel @Inject constructor(
     private val _signUpUiState = MutableLiveData<SignUpUiState>()
     val signUpUiState: LiveData<SignUpUiState> = _signUpUiState
 
-    private val _isCompleteSignUp = MutableLiveData(false)
-    val isCompleteSignUp: LiveData<Boolean> = _isCompleteSignUp
-
     private val _nameInputUiState = MutableLiveData<NameInputUiState>()
     val nameInputUiState: LiveData<NameInputUiState> = _nameInputUiState
 
@@ -39,11 +36,13 @@ class SignUpViewModel @Inject constructor(
             } else {
                 _nameInputUiState.value = NameInputUiState()
             }
-            _signUpUiState.value = SignUpUiState(true)
+            _signUpUiState.value = SignUpUiState(isRegistering = true)
             viewModelScope.launch {
-                userRepository.requestSignUp(name)
-                _signUpUiState.value = SignUpUiState()
-                _isCompleteSignUp.value = true
+                userRepository.requestSignUp(name).onSuccess {
+                    _signUpUiState.value = SignUpUiState(isCompleteSignUp = true)
+                }.onFailure {
+                    _signUpUiState.value = SignUpUiState(isErrorSignUp = false, signUpErrorMessageResId = R.string.signUp_signUpError)
+                }
             }
         }
     }

--- a/app/src/main/java/com/boosters/promise/ui/signup/SignUpViewModel.kt
+++ b/app/src/main/java/com/boosters/promise/ui/signup/SignUpViewModel.kt
@@ -27,13 +27,16 @@ class SignUpViewModel @Inject constructor(
     fun requestSignUp() {
         enterName.value?.let { name ->
             if (nameValidationRegex.matches(name).not()) {
-                _signUpUiState.value = SignUpUiState(false, R.string.signUp_inputError)
+                _signUpUiState.value = SignUpUiState(
+                    isNameValidationFail = true,
+                    errorText = R.string.signUp_inputError
+                )
                 return
             }
-            _signUpUiState.value = SignUpUiState(true, null)
+            _signUpUiState.value = SignUpUiState(true)
             viewModelScope.launch {
                 userRepository.requestSignUp(name)
-                _signUpUiState.value = SignUpUiState(false, null)
+                _signUpUiState.value = SignUpUiState()
                 _isCompleteSignUp.value = true
             }
         }

--- a/app/src/main/java/com/boosters/promise/ui/signup/SignUpViewModel.kt
+++ b/app/src/main/java/com/boosters/promise/ui/signup/SignUpViewModel.kt
@@ -21,7 +21,7 @@ class SignUpViewModel @Inject constructor(
 
     val enterName = MutableLiveData<String>()
 
-    private val _signUpUiState = MutableStateFlow(SignUpUiState())
+    private val _signUpUiState = MutableStateFlow<SignUpUiState>(SignUpUiState.Nothing)
     val signUpUiState = _signUpUiState.asStateFlow()
 
     private val _nameInputUiState = MutableStateFlow(NameInputUiState())
@@ -38,18 +38,16 @@ class SignUpViewModel @Inject constructor(
         }
         _nameInputUiState.value = NameInputUiState()
 
-        _signUpUiState.update { SignUpUiState(isRegistering = true) }
+        _signUpUiState.update { SignUpUiState.Loading }
         viewModelScope.launch {
             userRepository.requestSignUp(name).onSuccess {
-                _signUpUiState.update { SignUpUiState(isCompleteSignUp = true) }
+                _signUpUiState.update { SignUpUiState.Success }
             }.onFailure {
                 _signUpUiState.update {
-                    SignUpUiState(
-                        isErrorSignUp = false,
-                        signUpErrorMessageResId = R.string.signUp_signUpError
-                    )
+                    SignUpUiState.Fail(R.string.signUp_signUpError)
                 }
             }
+            _signUpUiState.update { SignUpUiState.Nothing }
         }
     }
 

--- a/app/src/main/java/com/boosters/promise/ui/signup/model/NameInputUiState.kt
+++ b/app/src/main/java/com/boosters/promise/ui/signup/model/NameInputUiState.kt
@@ -1,0 +1,8 @@
+package com.boosters.promise.ui.signup.model
+
+import androidx.annotation.StringRes
+
+data class NameInputUiState(
+    val isNameValidationFail: Boolean = false,
+    @StringRes val nameValidationErrorTextResId: Int? = null
+)

--- a/app/src/main/java/com/boosters/promise/ui/signup/model/SignUpUiState.kt
+++ b/app/src/main/java/com/boosters/promise/ui/signup/model/SignUpUiState.kt
@@ -2,9 +2,9 @@ package com.boosters.promise.ui.signup.model
 
 import androidx.annotation.StringRes
 
-data class SignUpUiState(
-    val isRegistering: Boolean = false,
-    val isCompleteSignUp: Boolean = false,
-    val isErrorSignUp: Boolean = false,
-    @StringRes val signUpErrorMessageResId: Int? = null
-)
+sealed interface SignUpUiState {
+    object Nothing : SignUpUiState
+    object Loading : SignUpUiState
+    object Success : SignUpUiState
+    class Fail(@StringRes val signUpErrorMessageResId: Int? = null) : SignUpUiState
+}

--- a/app/src/main/java/com/boosters/promise/ui/signup/model/SignUpUiState.kt
+++ b/app/src/main/java/com/boosters/promise/ui/signup/model/SignUpUiState.kt
@@ -1,9 +1,5 @@
 package com.boosters.promise.ui.signup.model
 
-import androidx.annotation.StringRes
-
 data class SignUpUiState(
-    val isRegistering: Boolean = false,
-    val isNameValidationFail: Boolean = false,
-    @StringRes val errorText: Int? = null
+    val isRegistering: Boolean = false
 )

--- a/app/src/main/java/com/boosters/promise/ui/signup/model/SignUpUiState.kt
+++ b/app/src/main/java/com/boosters/promise/ui/signup/model/SignUpUiState.kt
@@ -1,5 +1,10 @@
 package com.boosters.promise.ui.signup.model
 
+import androidx.annotation.StringRes
+
 data class SignUpUiState(
-    val isRegistering: Boolean = false
+    val isRegistering: Boolean = false,
+    val isCompleteSignUp: Boolean = false,
+    val isErrorSignUp: Boolean = false,
+    @StringRes val signUpErrorMessageResId: Int? = null
 )

--- a/app/src/main/java/com/boosters/promise/ui/signup/model/SignUpUiState.kt
+++ b/app/src/main/java/com/boosters/promise/ui/signup/model/SignUpUiState.kt
@@ -3,6 +3,7 @@ package com.boosters.promise.ui.signup.model
 import androidx.annotation.StringRes
 
 data class SignUpUiState(
-    val isRegistering: Boolean,
-    @StringRes val errorText: Int?
+    val isRegistering: Boolean = false,
+    val isNameValidationFail: Boolean = false,
+    @StringRes val errorText: Int? = null
 )

--- a/app/src/main/java/com/boosters/promise/ui/start/StartActivity.kt
+++ b/app/src/main/java/com/boosters/promise/ui/start/StartActivity.kt
@@ -5,6 +5,7 @@ import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import androidx.activity.viewModels
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
+import com.boosters.promise.ui.promise.PromiseSettingActivity
 import com.boosters.promise.ui.signup.SignUpActivity
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -16,19 +17,24 @@ class StartActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         installSplashScreen().apply {
             setKeepOnScreenCondition {
-                startViewModel.isSignUp.observe(this@StartActivity) { isSignUp ->
-                    if (isSignUp) {
-//                        startActivity(Intent(this@StartActivity, PromiseSettingActivity::class.java))
-                        // TODO: Home 약속 리스트 화면으로 이동 구현
-                    } else {
-                        startActivity(Intent(this@StartActivity, SignUpActivity::class.java))
-                    }
-                    finish()
-                }
+                initObserver()
                 true
             }
         }
         super.onCreate(savedInstanceState)
+    }
+
+    private fun initObserver() {
+        if (startViewModel.isSignUp.hasActiveObservers().not()) {
+            startViewModel.isSignUp.observe(this@StartActivity) { isSignUp ->
+                // TODO: Home 약속 리스트 화면으로 이동 구현
+                val intent = Intent(
+                    this@StartActivity,
+                    if (isSignUp) PromiseSettingActivity::class.java else SignUpActivity::class.java
+                )
+                startActivity(intent).also { finish() }
+            }
+        }
     }
 
 }

--- a/app/src/main/res/layout/activity_sign_up.xml
+++ b/app/src/main/res/layout/activity_sign_up.xml
@@ -70,7 +70,7 @@
 
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/textInputLayout_signUp_enterName"
-            style="@style/Promise.TextAppearance.MiddleNormal"
+            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             app:counterEnabled="true"

--- a/app/src/main/res/layout/activity_sign_up.xml
+++ b/app/src/main/res/layout/activity_sign_up.xml
@@ -18,8 +18,8 @@
             type="com.boosters.promise.ui.signup.model.NameInputUiState" />
 
         <variable
-            name="signUpUiState"
-            type="com.boosters.promise.ui.signup.model.SignUpUiState" />
+            name="isLoading"
+            type="Boolean" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -32,7 +32,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:indeterminate="true"
-            android:visibility="@{signUpUiState.isRegistering ? View.VISIBLE : View.INVISIBLE}"
+            android:visibility="@{isLoading ? View.VISIBLE : View.INVISIBLE}"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
@@ -107,7 +107,7 @@
             style="@style/Promise.Button.SquareButton"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:enabled="@{!signUpUiState.isRegistering}"
+            android:enabled="@{!isLoading}"
             android:text="@string/signUp_signUpRequest"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/activity_sign_up.xml
+++ b/app/src/main/res/layout/activity_sign_up.xml
@@ -7,9 +7,19 @@
 
         <import type="android.view.View" />
 
+        <import type="androidx.lifecycle.MutableLiveData" />
+
         <variable
-            name="signUpViewModel"
-            type="com.boosters.promise.ui.signup.SignUpViewModel" />
+            name="enterName"
+            type="MutableLiveData&lt;String&gt;" />
+
+        <variable
+            name="nameInputUiState"
+            type="com.boosters.promise.ui.signup.model.NameInputUiState" />
+
+        <variable
+            name="signUpUiState"
+            type="com.boosters.promise.ui.signup.model.SignUpUiState" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -22,7 +32,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:indeterminate="true"
-            android:visibility="@{signUpViewModel.signUpUiState.isRegistering ? View.VISIBLE : View.INVISIBLE}"
+            android:visibility="@{signUpUiState.isRegistering ? View.VISIBLE : View.INVISIBLE}"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
@@ -75,7 +85,7 @@
             android:layout_height="wrap_content"
             app:counterEnabled="true"
             app:counterMaxLength="6"
-            app:error='@{signUpViewModel.nameInputUiState.isNameValidationFail ? context.getString(signUpViewModel.nameInputUiState.nameValidationErrorTextResId) : ""}'
+            app:error='@{nameInputUiState.isNameValidationFail ? context.getString(nameInputUiState.nameValidationErrorTextResId) : ""}'
             app:layout_constraintBottom_toTopOf="@id/button_signUp_SignUpRequest"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
@@ -88,7 +98,7 @@
                 android:inputType="text"
                 android:maxLength="6"
                 android:maxLines="1"
-                android:text="@={signUpViewModel.enterName}" />
+                android:text="@={enterName}" />
 
         </com.google.android.material.textfield.TextInputLayout>
 
@@ -97,7 +107,7 @@
             style="@style/Promise.Button.SquareButton"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:enabled="@{!signUpViewModel.signUpUiState.isRegistering}"
+            android:enabled="@{!signUpUiState.isRegistering}"
             android:text="@string/signUp_signUpRequest"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/activity_sign_up.xml
+++ b/app/src/main/res/layout/activity_sign_up.xml
@@ -75,7 +75,7 @@
             android:layout_height="wrap_content"
             app:counterEnabled="true"
             app:counterMaxLength="6"
-            app:error='@{signUpViewModel.signUpUiState.errorText != null ? context.getString(signUpViewModel.signUpUiState.errorText) : ""}'
+            app:error='@{signUpViewModel.signUpUiState.isNameValidationFail ? context.getString(signUpViewModel.signUpUiState.errorText) : ""}'
             app:layout_constraintBottom_toTopOf="@id/button_signUp_SignUpRequest"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/activity_sign_up.xml
+++ b/app/src/main/res/layout/activity_sign_up.xml
@@ -75,7 +75,7 @@
             android:layout_height="wrap_content"
             app:counterEnabled="true"
             app:counterMaxLength="6"
-            app:error='@{signUpViewModel.signUpUiState.isNameValidationFail ? context.getString(signUpViewModel.signUpUiState.errorText) : ""}'
+            app:error='@{signUpViewModel.nameInputUiState.isNameValidationFail ? context.getString(signUpViewModel.nameInputUiState.nameValidationErrorTextResId) : ""}'
             app:layout_constraintBottom_toTopOf="@id/button_signUp_SignUpRequest"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -41,4 +41,5 @@
     <string name="signUp_title">환영합니다!</string>
     <string name="signUp_nameDescription">이름을 입력해주세요.</string>
     <string name="signUp_signUpRequest">시작하기</string>
+    <string name="signUp_signUpError">회원가입을 실패했습니다.</string>
 </resources>


### PR DESCRIPTION
## Issue
resolved #42
resolved #44
resolved #50
resolved #53

## Changed
### 새 기능
- 회원가입 실패 오류 시 snackBar로 실패 메시지 출력

### 리펙토링
- 회원가입 화면의 UiState 리펙토링
- LiveData를 StateFlow로 변경

### 버그 fix
- 회원가입 이름 입력 TextField 잘못된 스타일 지정 수정
-  UserRepository에서 requestSignUp에서 Result.Fail로 전달되는게 아니라 throw Exception하는 버그 해결
-  Splash screen 이후 동일한 다수의 activity가 생기는 버그 해결