### PR TITLE
약속 알림 추가, 수정 구분

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,6 +22,7 @@
 
         <activity
             android:name=".ui.detail.PromiseDetailActivity"
+            android:parentActivityName=".ui.promisecalendar.PromiseCalendarActivity"
             android:exported="false" />
 
         <activity

--- a/app/src/main/java/com/boosters/promise/ui/detail/PromiseDetailActivity.kt
+++ b/app/src/main/java/com/boosters/promise/ui/detail/PromiseDetailActivity.kt
@@ -2,12 +2,12 @@ package com.boosters.promise.ui.detail
 
 import android.content.Intent
 import android.os.Build
-import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
 import androidx.activity.viewModels
 import androidx.appcompat.app.AlertDialog
+import androidx.appcompat.app.AppCompatActivity
 import androidx.databinding.DataBindingUtil
 import com.boosters.promise.R
 import com.boosters.promise.data.model.Location
@@ -48,10 +48,9 @@ class PromiseDetailActivity : AppCompatActivity(), OnMapReadyCallback {
 
         promiseDetailViewModel.isDeleted.observe(this) {
             if (it) {
-                startActivity(
-                    Intent(this, PromiseCalendarActivity::class.java)
-                ).also { finish() }
-                finish()
+                val intent = Intent(this, PromiseCalendarActivity::class.java)
+                intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+                startActivity(intent)
             } else {
                 showStateSnackbar(R.string.promiseDetail_delete_ask)
             }

--- a/app/src/main/java/com/boosters/promise/ui/notification/NotificationService.kt
+++ b/app/src/main/java/com/boosters/promise/ui/notification/NotificationService.kt
@@ -35,7 +35,6 @@ class NotificationService : FirebaseMessagingService() {
 
         val intent = Intent(this, PromiseDetailActivity::class.java)
         intent.putExtra(PromiseCalendarActivity.PROMISE_INFO_KEY, promise.toPromiseUiState())
-        //intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
 
         val pendingIntent: PendingIntent? = TaskStackBuilder.create(this).run {
             addNextIntentWithParentStack(intent)
@@ -54,10 +53,15 @@ class NotificationService : FirebaseMessagingService() {
         }
         notificationManager.createNotificationChannel(channel)
 
+        val contentText = if (remoteMessage.data[MESSAGE_TITLE] == NOTIFICATION_EDIT) {
+            String.format(getString(R.string.notification_edit), promise.date)
+        } else {
+            String.format(getString(R.string.notification_add), promise.date)
+        }
         val builder = NotificationCompat.Builder(this, CHANNEL_ID)
             .setSmallIcon(R.mipmap.ic_launcher)
             .setContentTitle(promise.title)
-            .setContentText(String.format(getString(R.string.promiseSetting_notification), promise.date))
+            .setContentText(contentText)
             .setAutoCancel(true)
             .setContentIntent(pendingIntent)
             .setCategory(Notification.CATEGORY_MESSAGE)
@@ -69,6 +73,8 @@ class NotificationService : FirebaseMessagingService() {
         const val CHANNEL_ID = "my_channel"
         const val CHANNEL_NAME = "Notice"
         const val MESSAGE_BODY = "body"
+        const val MESSAGE_TITLE = "title"
+        const val NOTIFICATION_EDIT = "0"
     }
 
 }

--- a/app/src/main/java/com/boosters/promise/ui/notification/NotificationService.kt
+++ b/app/src/main/java/com/boosters/promise/ui/notification/NotificationService.kt
@@ -70,11 +70,11 @@ class NotificationService : FirebaseMessagingService() {
     }
 
     companion object {
-        const val CHANNEL_ID = "my_channel"
-        const val CHANNEL_NAME = "Notice"
-        const val MESSAGE_BODY = "body"
-        const val MESSAGE_TITLE = "title"
-        const val NOTIFICATION_EDIT = "0"
+        private const val CHANNEL_ID = "my_channel"
+        private const val CHANNEL_NAME = "Notice"
+        private const val MESSAGE_BODY = "body"
+        private const val MESSAGE_TITLE = "title"
+        private const val NOTIFICATION_EDIT = "0"
     }
 
 }

--- a/app/src/main/java/com/boosters/promise/ui/notification/NotificationService.kt
+++ b/app/src/main/java/com/boosters/promise/ui/notification/NotificationService.kt
@@ -7,6 +7,7 @@ import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import androidx.core.app.NotificationCompat
+import androidx.core.app.TaskStackBuilder
 import com.boosters.promise.R
 import com.boosters.promise.data.promise.Promise
 import com.boosters.promise.data.promise.toPromiseUiState
@@ -34,10 +35,12 @@ class NotificationService : FirebaseMessagingService() {
 
         val intent = Intent(this, PromiseDetailActivity::class.java)
         intent.putExtra(PromiseCalendarActivity.PROMISE_INFO_KEY, promise.toPromiseUiState())
-        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
+        //intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
 
-        val pendingIntent =
-            PendingIntent.getActivity(this, uniId, intent, PendingIntent.FLAG_IMMUTABLE)
+        val pendingIntent: PendingIntent? = TaskStackBuilder.create(this).run {
+            addNextIntentWithParentStack(intent)
+            getPendingIntent(0, PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT)
+        }
 
         val notificationManager =
             getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager

--- a/app/src/main/java/com/boosters/promise/ui/promisesetting/PromiseSettingActivity.kt
+++ b/app/src/main/java/com/boosters/promise/ui/promisesetting/PromiseSettingActivity.kt
@@ -84,11 +84,7 @@ class PromiseSettingActivity : AppCompatActivity() {
                 when (promiseSettingUiState) {
                     PromiseSettingUiState.Edit -> return@collectLatest
                     PromiseSettingUiState.Success -> {
-                        startActivity(
-                            Intent(this@PromiseSettingActivity, PromiseCalendarActivity::class.java)
-                        ).also {
-                            finish()
-                        }
+                        finish()
                     }
                     is PromiseSettingUiState.Fail -> showStateSnackbar(promiseSettingUiState.message)
                 }

--- a/app/src/main/java/com/boosters/promise/ui/promisesetting/PromiseSettingViewModel.kt
+++ b/app/src/main/java/com/boosters/promise/ui/promisesetting/PromiseSettingViewModel.kt
@@ -76,9 +76,7 @@ class PromiseSettingViewModel @Inject constructor(
         }
         viewModelScope.launch {
             val members = promise.members.toMutableList()
-            if (promise.promiseId.isEmpty()) members.add(
-                myInfo.copy(userToken = "").toUserUiState()
-            )
+            members.add(myInfo.copy(userToken = "").toUserUiState())
             promiseRepository.addPromise(promise.copy(members = members).toPromise()).collect {
                 when (it) {
                     true -> sendNotification()

--- a/app/src/main/java/com/boosters/promise/ui/promisesetting/PromiseSettingViewModel.kt
+++ b/app/src/main/java/com/boosters/promise/ui/promisesetting/PromiseSettingViewModel.kt
@@ -157,9 +157,9 @@ class PromiseSettingViewModel @Inject constructor(
     }
 
     companion object {
-        const val DATE_FORMAT = "yyyy/MM/dd HH:mm"
-        const val NOTIFICATION_EDIT = "0"
-        const val NOTIFICATION_ADD = "1"
+        private const val DATE_FORMAT = "yyyy/MM/dd HH:mm"
+        private const val NOTIFICATION_EDIT = "0"
+        private const val NOTIFICATION_ADD = "1"
     }
 
 }

--- a/app/src/main/java/com/boosters/promise/ui/promisesetting/PromiseSettingViewModel.kt
+++ b/app/src/main/java/com/boosters/promise/ui/promisesetting/PromiseSettingViewModel.kt
@@ -139,9 +139,14 @@ class PromiseSettingViewModel @Inject constructor(
                 return@launch
             }
             val key = serverKeyRepository.getServerKey()
+            val title = if (_promiseUiState.value.promiseId.isEmpty()) {
+                NOTIFICATION_ADD
+            } else {
+                NOTIFICATION_EDIT
+            }
             userRepository.getUserList(userCodeList).forEach { user ->
                 notificationRepository.sendNotification(
-                    _promiseUiState.value.title,
+                    title,
                     _promiseUiState.value.toPromise(),
                     user.userToken,
                     key
@@ -153,6 +158,8 @@ class PromiseSettingViewModel @Inject constructor(
 
     companion object {
         const val DATE_FORMAT = "yyyy/MM/dd HH:mm"
+        const val NOTIFICATION_EDIT = "0"
+        const val NOTIFICATION_ADD = "1"
     }
 
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -65,7 +65,7 @@
     <string name="promiseDetail_date_format">%s, %s</string>
     <string name="promiseDetail_member">약속 멤버</string>
     <string name="promiseDetail_delete_fail">삭제에 실패했습니다.</string>
-    <string name="promiseDetail_delete_ask">삭제하시겠습까?</string>
+    <string name="promiseDetail_delete_ask">삭제하시겠습니까?</string>
     <string name="promiseDetail_dialog_yes">YES</string>
     <string name="promiseDetail_dialog_no">NO</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -20,7 +20,6 @@
     <string name="promiseSetting_fail">저장에 실패했습니다.</string>
     <string name="promiseSetting_empty">약속 정보를 모두 채워주세요.</string>
     <string name="promiseSetting_beforeTime">현재보다 이후의 시간으로 설정해주세요.</string>
-    <string name="promiseSetting_notification">[%s] 새로운 약속이 추가되었니다.</string>
 
     <!-- 약속 추가 다이얼로그 -->
     <string name="date_format">%d/%02d/%02d</string>
@@ -69,4 +68,9 @@
     <string name="promiseDetail_delete_ask">삭제하시겠습까?</string>
     <string name="promiseDetail_dialog_yes">YES</string>
     <string name="promiseDetail_dialog_no">NO</string>
+
+    <!-- 알림 -->
+    <string name="notification_add">[%s] 새로운 약속이 추가되었습니다.</string>
+    <string name="notification_edit">[%s] 약속이 수정되었습니다.</string>
+
 </resources>


### PR DESCRIPTION
## Issue
resolved #91
resolved #63

## Changes
- 약속 알림 추가, 수정 구분 
    - 추가된 약속이면 "새로운 약속이 추가되었습니다."
    - 수정된 약속이면 "약속이 수정되었습니다.
- 푸쉬 알림 탭 시 상세화면으로 이동
    - 뒤로가기 시 캘린더 화면으로 이동됨.


## ScreenShot
<img src="https://user-images.githubusercontent.com/67852426/203729732-dcd75942-2db9-4651-82d1-9f1e289888c8.mov" width="40%"/>

<img src="https://user-images.githubusercontent.com/67852426/203729583-17085ad6-0349-43b1-8bad-50ea6467b26c.mov" width="40%"/>

<img src="https://user-images.githubusercontent.com/67852426/203730074-55e0d53f-26e1-474d-90f8-03da847058a9.mov" width="40%"/>