### PR TITLE
위치 공유 On/Off 스위치 추가

### DIFF
--- a/app/src/main/java/com/boosters/promise/data/location/LocationRepository.kt
+++ b/app/src/main/java/com/boosters/promise/data/location/LocationRepository.kt
@@ -1,5 +1,6 @@
 package com.boosters.promise.data.location
 
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 
 interface LocationRepository {
@@ -11,5 +12,13 @@ interface LocationRepository {
     fun startLocationUpdates(): Result<Unit>
 
     fun stopLocationUpdates()
+
+    suspend fun uploadMyGeoLocation(geoLocation: GeoLocation): Result<Unit>
+
+    suspend fun resetMyGeoLocation()
+
+    fun getGeoLocation(userCode: String): Flow<UserGeoLocation>
+
+    fun getGeoLocations(userCodes: List<String>): Flow<List<UserGeoLocation>>
 
 }

--- a/app/src/main/java/com/boosters/promise/data/location/LocationRepositoryImpl.kt
+++ b/app/src/main/java/com/boosters/promise/data/location/LocationRepositoryImpl.kt
@@ -2,17 +2,19 @@ package com.boosters.promise.data.location
 
 import android.location.Location
 import android.os.HandlerThread
+import com.boosters.promise.data.location.source.remote.LocationRemoteDataSource
+import com.boosters.promise.data.location.source.remote.toUserGeoLocation
+import com.boosters.promise.data.user.source.local.MyInfoLocalDataSource
 import com.google.android.gms.location.*
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.flow.*
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 class LocationRepositoryImpl @Inject constructor(
-    private val fusedLocationProviderClient: FusedLocationProviderClient
+    private val fusedLocationProviderClient: FusedLocationProviderClient,
+    private val myInfoLocalDataSource: MyInfoLocalDataSource,
+    private val locationRemoteDataSource: LocationRemoteDataSource
 ) : LocationRepository {
 
     private val _locationUpdateRequestCount = MutableStateFlow(0)
@@ -66,6 +68,40 @@ class LocationRepositoryImpl @Inject constructor(
             latitude,
             longitude
         )
+
+    override suspend fun uploadMyGeoLocation(geoLocation: GeoLocation): Result<Unit> = runCatching {
+        val user = myInfoLocalDataSource.getMyInfo().first().getOrThrow()
+        locationRemoteDataSource.uploadGeoLocation(user.userCode, geoLocation)
+    }
+
+    override suspend fun resetMyGeoLocation() {
+        val user = myInfoLocalDataSource.getMyInfo().first().getOrNull()
+        if (user != null) {
+            locationRemoteDataSource.resetMyGeoLocation(user.userCode)
+        }
+    }
+
+    override fun getGeoLocation(userCode: String): Flow<UserGeoLocation> {
+        return locationRemoteDataSource.getGeoLocation(userCode).mapNotNull {
+            try {
+                it.toUserGeoLocation()
+            } catch (e: NullPointerException) {
+                null
+            }
+        }
+    }
+
+    override fun getGeoLocations(userCodes: List<String>): Flow<List<UserGeoLocation>> {
+        return locationRemoteDataSource.getGeoLocations(userCodes).map { userGeoLocationBodies ->
+            userGeoLocationBodies.mapNotNull {
+                try {
+                    it.toUserGeoLocation()
+                } catch (e: NullPointerException) {
+                    null
+                }
+            }
+        }
+    }
 
     companion object {
         private const val INTERVAL_MILLIS = 10_000L

--- a/app/src/main/java/com/boosters/promise/data/location/LocationRepositoryImpl.kt
+++ b/app/src/main/java/com/boosters/promise/data/location/LocationRepositoryImpl.kt
@@ -54,8 +54,7 @@ class LocationRepositoryImpl @Inject constructor(
     }
 
     override fun stopLocationUpdates() {
-        _locationUpdateRequestCount.update { locationUpdateRequestCount.value - 1 }
-
+        _locationUpdateRequestCount.update { (locationUpdateRequestCount.value - 1).coerceAtLeast(0) }
         if (locationUpdateRequestCount.value < 1) {
             fusedLocationProviderClient.removeLocationUpdates(callback)
             _lastGeoLocation.value = null

--- a/app/src/main/java/com/boosters/promise/data/location/UserGeoLocation.kt
+++ b/app/src/main/java/com/boosters/promise/data/location/UserGeoLocation.kt
@@ -1,0 +1,6 @@
+package com.boosters.promise.data.location
+
+data class UserGeoLocation(
+    val userCode: String,
+    val geoLocation: GeoLocation?
+)

--- a/app/src/main/java/com/boosters/promise/data/location/di/LocationModule.kt
+++ b/app/src/main/java/com/boosters/promise/data/location/di/LocationModule.kt
@@ -5,16 +5,31 @@ import com.boosters.promise.data.location.LocationRepository
 import com.boosters.promise.data.location.LocationRepositoryImpl
 import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationServices.getFusedLocationProviderClient
+import com.google.firebase.firestore.CollectionReference
+import com.google.firebase.firestore.ktx.firestore
+import com.google.firebase.ktx.Firebase
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
+import javax.inject.Qualifier
 import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
 object LocationModule {
+
+    private const val LOCATIONS_PATH = "locations"
+
+    @Qualifier
+    @Retention(AnnotationRetention.BINARY)
+    annotation class LocationCollectionReference
+
+    @LocationCollectionReference
+    @Singleton
+    @Provides
+    fun provideLocationReference(): CollectionReference = Firebase.firestore.collection(LOCATIONS_PATH)
 
     @Provides
     @Singleton

--- a/app/src/main/java/com/boosters/promise/data/location/source/remote/LocationRemoteDataSource.kt
+++ b/app/src/main/java/com/boosters/promise/data/location/source/remote/LocationRemoteDataSource.kt
@@ -1,0 +1,66 @@
+package com.boosters.promise.data.location.source.remote
+
+import com.boosters.promise.data.location.GeoLocation
+import com.boosters.promise.data.location.di.LocationModule.LocationCollectionReference
+import com.boosters.promise.data.network.NetworkConnectionUtil
+import com.google.firebase.firestore.CollectionReference
+import com.google.firebase.firestore.ktx.snapshots
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.mapNotNull
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class LocationRemoteDataSource @Inject constructor(
+    @LocationCollectionReference private val locationCollectionReference: CollectionReference,
+    private val networkConnectionUtil: NetworkConnectionUtil
+) {
+
+    fun uploadGeoLocation(userCode: String, geoLocation: GeoLocation?): Result<Unit> = runCatching {
+        networkConnectionUtil.checkNetworkOnline()
+
+        locationCollectionReference
+            .whereEqualTo(USER_CODE_KEY, userCode)
+            .limit(1)
+            .get()
+            .addOnSuccessListener { documents ->
+                if (documents.isEmpty) {
+                    locationCollectionReference.document().set(
+                        UserGeoLocationBody(
+                            userCode = userCode,
+                            geoLocation = geoLocation
+                        )
+                    )
+                } else {
+                    locationCollectionReference.document(documents.first().id)
+                        .update(GEO_LOCATION_FIELD, geoLocation)
+                }
+            }
+    }
+
+    fun resetMyGeoLocation(userCode: String) {
+        uploadGeoLocation(userCode, null)
+    }
+
+    fun getGeoLocation(userCode: String): Flow<UserGeoLocationBody> =
+        locationCollectionReference
+            .document(userCode)
+            .snapshots()
+            .mapNotNull {
+                it.toObject(UserGeoLocationBody::class.java)
+            }
+
+    fun getGeoLocations(userCodes: List<String>): Flow<List<UserGeoLocationBody>> =
+        locationCollectionReference
+            .whereEqualTo(USER_CODE_KEY, userCodes)
+            .snapshots()
+            .map {
+                it.toObjects(UserGeoLocationBody::class.java)
+            }
+
+    private companion object {
+        const val USER_CODE_KEY = "userCode"
+        const val GEO_LOCATION_FIELD = "geoLocation"
+    }
+}

--- a/app/src/main/java/com/boosters/promise/data/location/source/remote/UserGeoLocationBody.kt
+++ b/app/src/main/java/com/boosters/promise/data/location/source/remote/UserGeoLocationBody.kt
@@ -1,0 +1,15 @@
+package com.boosters.promise.data.location.source.remote
+
+import com.boosters.promise.data.location.GeoLocation
+import com.boosters.promise.data.location.UserGeoLocation
+
+data class UserGeoLocationBody(
+    val userCode: String? = null,
+    val geoLocation: GeoLocation? = null
+)
+
+fun UserGeoLocationBody.toUserGeoLocation() =
+    UserGeoLocation(
+        userCode = userCode ?: throw NullPointerException(),
+        geoLocation = geoLocation
+    )

--- a/app/src/main/java/com/boosters/promise/data/member/Member.kt
+++ b/app/src/main/java/com/boosters/promise/data/member/Member.kt
@@ -12,5 +12,5 @@ fun Member.toMemberBody() =
     MemberBody(
         promiseId = promiseId,
         userCode = userCode,
-        isAcceptLocation = isAcceptLocation
+        acceptLocation = isAcceptLocation
     )

--- a/app/src/main/java/com/boosters/promise/data/member/Member.kt
+++ b/app/src/main/java/com/boosters/promise/data/member/Member.kt
@@ -1,0 +1,16 @@
+package com.boosters.promise.data.member
+
+import com.boosters.promise.data.member.source.remote.MemberBody
+
+data class Member(
+    val promiseId: String,
+    val userCode: String,
+    val isAcceptLocation: Boolean
+)
+
+fun Member.toMemberBody() =
+    MemberBody(
+        promiseId = promiseId,
+        userCode = userCode,
+        isAcceptLocation = isAcceptLocation
+    )

--- a/app/src/main/java/com/boosters/promise/data/member/MemberRepository.kt
+++ b/app/src/main/java/com/boosters/promise/data/member/MemberRepository.kt
@@ -14,6 +14,6 @@ interface MemberRepository {
 
     suspend fun removeIsAcceptLocation(promiseId: String)
 
-    suspend fun getIsAcceptLocation(promiseId: String): Flow<Result<Boolean>>
+    fun getIsAcceptLocation(promiseId: String): Flow<Result<Boolean>>
 
 }

--- a/app/src/main/java/com/boosters/promise/data/member/MemberRepository.kt
+++ b/app/src/main/java/com/boosters/promise/data/member/MemberRepository.kt
@@ -6,8 +6,10 @@ interface MemberRepository {
 
     fun initMember(promiseId: String, userCodes: List<String>): Result<Unit>
 
-    fun updateIsAcceptLocation(member: Member): Result<Unit>
-
     fun getMembers(promiseId: String): Flow<List<Member>>
+
+    suspend fun updateIsAcceptLocation(member: Member): Result<Unit>
+
+    suspend fun getIsAcceptLocation(promiseId: String): Flow<Result<Boolean>>
 
 }

--- a/app/src/main/java/com/boosters/promise/data/member/MemberRepository.kt
+++ b/app/src/main/java/com/boosters/promise/data/member/MemberRepository.kt
@@ -10,6 +10,8 @@ interface MemberRepository {
 
     suspend fun updateIsAcceptLocation(member: Member): Result<Unit>
 
+    suspend fun removeIsAcceptLocation(promiseId: String)
+
     suspend fun getIsAcceptLocation(promiseId: String): Flow<Result<Boolean>>
 
 }

--- a/app/src/main/java/com/boosters/promise/data/member/MemberRepository.kt
+++ b/app/src/main/java/com/boosters/promise/data/member/MemberRepository.kt
@@ -1,0 +1,13 @@
+package com.boosters.promise.data.member
+
+import kotlinx.coroutines.flow.Flow
+
+interface MemberRepository {
+
+    fun initMember(promiseId: String, userCodes: List<String>): Result<Unit>
+
+    fun updateIsAcceptLocation(member: Member): Result<Unit>
+
+    fun getMembers(promiseId: String): Flow<List<Member>>
+
+}

--- a/app/src/main/java/com/boosters/promise/data/member/MemberRepository.kt
+++ b/app/src/main/java/com/boosters/promise/data/member/MemberRepository.kt
@@ -8,6 +8,8 @@ interface MemberRepository {
 
     fun getMembers(promiseId: String): Flow<List<Member>>
 
+    suspend fun addIsAcceptLocation(promiseId: String)
+
     suspend fun updateIsAcceptLocation(member: Member): Result<Unit>
 
     suspend fun removeIsAcceptLocation(promiseId: String)

--- a/app/src/main/java/com/boosters/promise/data/member/MemberRepositoryImpl.kt
+++ b/app/src/main/java/com/boosters/promise/data/member/MemberRepositoryImpl.kt
@@ -43,7 +43,7 @@ class MemberRepositoryImpl @Inject constructor(
         locationSharingPermissionLocalDataSource.removeLocationSharingPermission(promiseId)
     }
 
-    override suspend fun getIsAcceptLocation(promiseId: String): Flow<Result<Boolean>> =
+    override fun getIsAcceptLocation(promiseId: String): Flow<Result<Boolean>> =
         locationSharingPermissionLocalDataSource.getLocationSharingPermission(promiseId)
 
 }

--- a/app/src/main/java/com/boosters/promise/data/member/MemberRepositoryImpl.kt
+++ b/app/src/main/java/com/boosters/promise/data/member/MemberRepositoryImpl.kt
@@ -30,6 +30,10 @@ class MemberRepositoryImpl @Inject constructor(
         }
     }
 
+    override suspend fun addIsAcceptLocation(promiseId: String) {
+        locationSharingPermissionLocalDataSource.saveLocationSharingPermission(promiseId, false)
+    }
+
     override suspend fun updateIsAcceptLocation(member: Member): Result<Unit> =
         memberRemoteDataSource.updateIsAcceptLocation(member.toMemberBody()).mapCatching {
             locationSharingPermissionLocalDataSource.saveLocationSharingPermission(member.promiseId, member.isAcceptLocation)

--- a/app/src/main/java/com/boosters/promise/data/member/MemberRepositoryImpl.kt
+++ b/app/src/main/java/com/boosters/promise/data/member/MemberRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package com.boosters.promise.data.member
 
+import com.boosters.promise.data.member.source.local.LocationSharingPermissionLocalDataSource
 import com.boosters.promise.data.member.source.remote.MemberRemoteDataSource
 import com.boosters.promise.data.member.source.remote.toMember
 import kotlinx.coroutines.flow.Flow
@@ -9,15 +10,12 @@ import javax.inject.Singleton
 
 @Singleton
 class MemberRepositoryImpl @Inject constructor(
-    private val memberRemoteDataSource: MemberRemoteDataSource
+    private val memberRemoteDataSource: MemberRemoteDataSource,
+    private val locationSharingPermissionLocalDataSource: LocationSharingPermissionLocalDataSource
 ) : MemberRepository {
 
     override fun initMember(promiseId: String, userCodes: List<String>): Result<Unit> {
         return memberRemoteDataSource.initMembers(promiseId, userCodes)
-    }
-
-    override fun updateIsAcceptLocation(member: Member): Result<Unit> {
-        return memberRemoteDataSource.updateIsAcceptLocation(member.toMemberBody())
     }
 
     override fun getMembers(promiseId: String): Flow<List<Member>> {
@@ -31,5 +29,13 @@ class MemberRepositoryImpl @Inject constructor(
             }
         }
     }
+
+    override suspend fun updateIsAcceptLocation(member: Member): Result<Unit> =
+        memberRemoteDataSource.updateIsAcceptLocation(member.toMemberBody()).mapCatching {
+            locationSharingPermissionLocalDataSource.saveLocationSharingPermission(member.promiseId, member.isAcceptLocation)
+        }
+
+    override suspend fun getIsAcceptLocation(promiseId: String): Flow<Result<Boolean>> =
+        locationSharingPermissionLocalDataSource.getLocationSharingPermission(promiseId)
 
 }

--- a/app/src/main/java/com/boosters/promise/data/member/MemberRepositoryImpl.kt
+++ b/app/src/main/java/com/boosters/promise/data/member/MemberRepositoryImpl.kt
@@ -35,6 +35,10 @@ class MemberRepositoryImpl @Inject constructor(
             locationSharingPermissionLocalDataSource.saveLocationSharingPermission(member.promiseId, member.isAcceptLocation)
         }
 
+    override suspend fun removeIsAcceptLocation(promiseId: String) {
+        locationSharingPermissionLocalDataSource.removeLocationSharingPermission(promiseId)
+    }
+
     override suspend fun getIsAcceptLocation(promiseId: String): Flow<Result<Boolean>> =
         locationSharingPermissionLocalDataSource.getLocationSharingPermission(promiseId)
 

--- a/app/src/main/java/com/boosters/promise/data/member/MemberRepositoryImpl.kt
+++ b/app/src/main/java/com/boosters/promise/data/member/MemberRepositoryImpl.kt
@@ -1,0 +1,35 @@
+package com.boosters.promise.data.member
+
+import com.boosters.promise.data.member.source.remote.MemberRemoteDataSource
+import com.boosters.promise.data.member.source.remote.toMember
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class MemberRepositoryImpl @Inject constructor(
+    private val memberRemoteDataSource: MemberRemoteDataSource
+) : MemberRepository {
+
+    override fun initMember(promiseId: String, userCodes: List<String>): Result<Unit> {
+        return memberRemoteDataSource.initMembers(promiseId, userCodes)
+    }
+
+    override fun updateIsAcceptLocation(member: Member): Result<Unit> {
+        return memberRemoteDataSource.updateIsAcceptLocation(member.toMemberBody())
+    }
+
+    override fun getMembers(promiseId: String): Flow<List<Member>> {
+        return memberRemoteDataSource.getMembers(promiseId).map { members ->
+            members.mapNotNull { memberBody ->
+                try {
+                    memberBody.toMember()
+                } catch (e: NullPointerException) {
+                    null
+                }
+            }
+        }
+    }
+
+}

--- a/app/src/main/java/com/boosters/promise/data/member/di/MemberModule.kt
+++ b/app/src/main/java/com/boosters/promise/data/member/di/MemberModule.kt
@@ -1,0 +1,36 @@
+package com.boosters.promise.data.member.di
+
+import com.boosters.promise.data.member.MemberRepository
+import com.boosters.promise.data.member.MemberRepositoryImpl
+import com.google.firebase.firestore.CollectionReference
+import com.google.firebase.firestore.ktx.firestore
+import com.google.firebase.ktx.Firebase
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Qualifier
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object MemberModule {
+
+    private const val MEMBERS_PATH = "members"
+
+    @Qualifier
+    @Retention(AnnotationRetention.BINARY)
+    annotation class MemberCollectionReference
+
+    @MemberCollectionReference
+    @Singleton
+    @Provides
+    fun provideMemberCollectionReference(): CollectionReference = Firebase.firestore.collection(MEMBERS_PATH)
+
+    @Singleton
+    @Provides
+    fun provideMemberRepository(
+        memberRepositoryImpl: MemberRepositoryImpl
+    ): MemberRepository = memberRepositoryImpl
+
+}

--- a/app/src/main/java/com/boosters/promise/data/member/di/MemberModule.kt
+++ b/app/src/main/java/com/boosters/promise/data/member/di/MemberModule.kt
@@ -1,5 +1,12 @@
 package com.boosters.promise.data.member.di
 
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.preferencesDataStoreFile
 import com.boosters.promise.data.member.MemberRepository
 import com.boosters.promise.data.member.MemberRepositoryImpl
 import com.google.firebase.firestore.CollectionReference
@@ -8,6 +15,7 @@ import com.google.firebase.ktx.Firebase
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import javax.inject.Qualifier
 import javax.inject.Singleton
@@ -17,15 +25,32 @@ import javax.inject.Singleton
 object MemberModule {
 
     private const val MEMBERS_PATH = "members"
+    private const val LOCATION_SHARING_PERMISSION_PREFERENCES_NAME = "locationSharingPreferences"
 
     @Qualifier
     @Retention(AnnotationRetention.BINARY)
     annotation class MemberCollectionReference
 
+    @Qualifier
+    @Retention(AnnotationRetention.BINARY)
+    annotation class LocationSharingPermissionPreferences
+
     @MemberCollectionReference
     @Singleton
     @Provides
     fun provideMemberCollectionReference(): CollectionReference = Firebase.firestore.collection(MEMBERS_PATH)
+
+    @LocationSharingPermissionPreferences
+    @Singleton
+    @Provides
+    fun provideLocationSharingPermissionPreferences(@ApplicationContext applicationContext: Context): DataStore<Preferences> {
+        return PreferenceDataStoreFactory.create(
+            corruptionHandler = ReplaceFileCorruptionHandler {
+                emptyPreferences()
+            },
+            produceFile = { applicationContext.preferencesDataStoreFile(LOCATION_SHARING_PERMISSION_PREFERENCES_NAME) }
+        )
+    }
 
     @Singleton
     @Provides

--- a/app/src/main/java/com/boosters/promise/data/member/source/local/LocationSharingPermissionLocalDataSource.kt
+++ b/app/src/main/java/com/boosters/promise/data/member/source/local/LocationSharingPermissionLocalDataSource.kt
@@ -24,6 +24,12 @@ class LocationSharingPermissionLocalDataSource @Inject constructor(
         }
     }
 
+    suspend fun removeLocationSharingPermission(promiseId: String) {
+        locationSharingPermissionPreferences.edit { preferences ->
+            preferences.remove(booleanPreferencesKey(promiseId))
+        }
+    }
+
     fun getLocationSharingPermission(promiseId: String): Flow<Result<Boolean>> =
         locationSharingPermissionPreferences.data.catch { exception ->
             if (exception is IOException) emit(emptyPreferences())

--- a/app/src/main/java/com/boosters/promise/data/member/source/local/LocationSharingPermissionLocalDataSource.kt
+++ b/app/src/main/java/com/boosters/promise/data/member/source/local/LocationSharingPermissionLocalDataSource.kt
@@ -1,0 +1,36 @@
+package com.boosters.promise.data.member.source.local
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
+import com.boosters.promise.data.member.di.MemberModule.LocationSharingPermissionPreferences
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.map
+import java.io.IOException
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class LocationSharingPermissionLocalDataSource @Inject constructor(
+    @LocationSharingPermissionPreferences private val locationSharingPermissionPreferences: DataStore<Preferences>
+) {
+
+    suspend fun saveLocationSharingPermission(promiseId: String, isLocationSharing: Boolean) {
+        locationSharingPermissionPreferences.edit { preferences ->
+            preferences[booleanPreferencesKey(promiseId)] = isLocationSharing
+        }
+    }
+
+    fun getLocationSharingPermission(promiseId: String): Flow<Result<Boolean>> =
+        locationSharingPermissionPreferences.data.catch { exception ->
+            if (exception is IOException) emit(emptyPreferences())
+        }.map { preferences ->
+            runCatching {
+                preferences[booleanPreferencesKey(promiseId)] ?: throw NullPointerException()
+            }
+        }
+
+}

--- a/app/src/main/java/com/boosters/promise/data/member/source/remote/MemberBody.kt
+++ b/app/src/main/java/com/boosters/promise/data/member/source/remote/MemberBody.kt
@@ -1,0 +1,16 @@
+package com.boosters.promise.data.member.source.remote
+
+import com.boosters.promise.data.member.Member
+
+data class MemberBody(
+    val promiseId: String?,
+    val userCode: String?,
+    val isAcceptLocation: Boolean? = false
+)
+
+fun MemberBody.toMember() =
+    Member(
+        promiseId = promiseId.orEmpty(),
+        userCode = userCode ?: throw NullPointerException(),
+        isAcceptLocation = isAcceptLocation ?: false
+    )

--- a/app/src/main/java/com/boosters/promise/data/member/source/remote/MemberBody.kt
+++ b/app/src/main/java/com/boosters/promise/data/member/source/remote/MemberBody.kt
@@ -5,12 +5,12 @@ import com.boosters.promise.data.member.Member
 data class MemberBody(
     val promiseId: String?,
     val userCode: String?,
-    val isAcceptLocation: Boolean? = false
+    val acceptLocation: Boolean? = false
 )
 
 fun MemberBody.toMember() =
     Member(
         promiseId = promiseId.orEmpty(),
         userCode = userCode ?: throw NullPointerException(),
-        isAcceptLocation = isAcceptLocation ?: false
+        isAcceptLocation = acceptLocation ?: false
     )

--- a/app/src/main/java/com/boosters/promise/data/member/source/remote/MemberBody.kt
+++ b/app/src/main/java/com/boosters/promise/data/member/source/remote/MemberBody.kt
@@ -3,8 +3,8 @@ package com.boosters.promise.data.member.source.remote
 import com.boosters.promise.data.member.Member
 
 data class MemberBody(
-    val promiseId: String?,
-    val userCode: String?,
+    val promiseId: String? = null,
+    val userCode: String? = null,
     val acceptLocation: Boolean? = false
 )
 

--- a/app/src/main/java/com/boosters/promise/data/member/source/remote/MemberRemoteDataSource.kt
+++ b/app/src/main/java/com/boosters/promise/data/member/source/remote/MemberRemoteDataSource.kt
@@ -1,0 +1,54 @@
+package com.boosters.promise.data.member.source.remote
+
+import com.boosters.promise.data.member.di.MemberModule
+import com.boosters.promise.data.network.NetworkConnectionUtil
+import com.google.firebase.firestore.CollectionReference
+import com.google.firebase.firestore.ktx.snapshots
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.mapNotNull
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class MemberRemoteDataSource @Inject constructor(
+    @MemberModule.MemberCollectionReference private val memberCollectionReference: CollectionReference,
+    private val networkConnectionUtil: NetworkConnectionUtil
+) {
+
+    fun initMembers(promiseId: String, userCodes: List<String>): Result<Unit> = runCatching {
+        networkConnectionUtil.checkNetworkOnline()
+
+        userCodes.forEach { userCode ->
+            memberCollectionReference.document().set(
+                MemberBody(promiseId, userCode)
+            )
+        }
+    }
+
+    fun updateIsAcceptLocation(memberBody: MemberBody): Result<Unit> = runCatching {
+        networkConnectionUtil.checkNetworkOnline()
+
+        memberCollectionReference
+            .whereEqualTo(PROMISE_ID_KEY, memberBody.promiseId)
+            .whereEqualTo(USER_CODE_KEY, memberBody.userCode)
+            .get()
+            .addOnSuccessListener { documents ->
+                for (document in documents) {
+                    memberCollectionReference.document(document.id)
+                        .update(IS_ACCEPT_LOCATION_KEY, memberBody.isAcceptLocation)
+                }
+            }
+    }
+
+    fun getMembers(promiseId: String): Flow<List<MemberBody>> =
+        memberCollectionReference.whereEqualTo(PROMISE_ID_KEY, promiseId).snapshots().mapNotNull {
+            it.toObjects(MemberBody::class.java)
+        }
+
+    private companion object {
+        const val PROMISE_ID_KEY = "promiseId"
+        const val USER_CODE_KEY = "userCode"
+        const val IS_ACCEPT_LOCATION_KEY = "isAcceptLocation"
+    }
+
+}

--- a/app/src/main/java/com/boosters/promise/data/member/source/remote/MemberRemoteDataSource.kt
+++ b/app/src/main/java/com/boosters/promise/data/member/source/remote/MemberRemoteDataSource.kt
@@ -35,7 +35,7 @@ class MemberRemoteDataSource @Inject constructor(
             .addOnSuccessListener { documents ->
                 for (document in documents) {
                     memberCollectionReference.document(document.id)
-                        .update(IS_ACCEPT_LOCATION_KEY, memberBody.isAcceptLocation)
+                        .update(IS_ACCEPT_LOCATION_KEY, memberBody.acceptLocation)
                 }
             }
     }
@@ -48,7 +48,7 @@ class MemberRemoteDataSource @Inject constructor(
     private companion object {
         const val PROMISE_ID_KEY = "promiseId"
         const val USER_CODE_KEY = "userCode"
-        const val IS_ACCEPT_LOCATION_KEY = "isAcceptLocation"
+        const val IS_ACCEPT_LOCATION_KEY = "acceptLocation"
     }
 
 }

--- a/app/src/main/java/com/boosters/promise/data/promise/Promise.kt
+++ b/app/src/main/java/com/boosters/promise/data/promise/Promise.kt
@@ -14,7 +14,7 @@ data class Promise(
     val destinationGeoLocation: GeoLocation = GeoLocation(),
     val date: String = "",
     val time: String = "",
-    val members: List<User> = listOf()
+    val members: List<User> = emptyList()
 ) : Parcelable
 
 fun Promise.toPromiseBody() =
@@ -25,5 +25,5 @@ fun Promise.toPromiseBody() =
         destinationGeoLocation = destinationGeoLocation,
         date = date,
         time = time,
-        members = members
+        members = members.map { it.userCode }
     )

--- a/app/src/main/java/com/boosters/promise/data/promise/PromiseRepository.kt
+++ b/app/src/main/java/com/boosters/promise/data/promise/PromiseRepository.kt
@@ -5,7 +5,7 @@ import kotlinx.coroutines.flow.Flow
 
 interface PromiseRepository {
 
-    fun addPromise(promise: Promise): Flow<Boolean>
+    suspend fun addPromise(promise: Promise): Flow<Boolean>
 
     fun removePromise(promiseId: String): Flow<Boolean>
 

--- a/app/src/main/java/com/boosters/promise/data/promise/PromiseRepositoryImpl.kt
+++ b/app/src/main/java/com/boosters/promise/data/promise/PromiseRepositoryImpl.kt
@@ -3,12 +3,16 @@ package com.boosters.promise.data.promise
 import com.boosters.promise.data.promise.source.remote.PromiseRemoteDataSource
 import com.boosters.promise.data.promise.source.remote.toPromise
 import com.boosters.promise.data.user.User
+import com.boosters.promise.data.user.UserRepository
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapNotNull
 import javax.inject.Inject
 
 class PromiseRepositoryImpl @Inject constructor(
     private val promiseRemoteDataSource: PromiseRemoteDataSource,
+    private val userRepository: UserRepository
 ) : PromiseRepository {
 
     override fun addPromise(promise: Promise): Flow<Boolean> {
@@ -20,15 +24,19 @@ class PromiseRepositoryImpl @Inject constructor(
     }
 
     override fun getPromise(promiseId: String): Flow<Promise> {
-        return promiseRemoteDataSource.getPromise(promiseId).mapNotNull { it.toPromise() }
+        return promiseRemoteDataSource.getPromise(promiseId).mapNotNull { promiseBody ->
+            promiseBody.toPromise(userRepository.getUserList(promiseBody.members).first())
+        }
     }
 
     override fun getPromiseList(user: User, date: String): Flow<List<Promise>> {
-        return promiseRemoteDataSource.getPromiseList(user, date).mapNotNull { promiseList ->
-            try {
-                promiseList.map { it.toPromise() }
-            } catch (e: NullPointerException) {
-                null
+        return promiseRemoteDataSource.getPromiseList(user, date).map { promiseList ->
+            promiseList.mapNotNull { promiseBody ->
+                try {
+                    promiseBody.toPromise(userRepository.getUserList(promiseBody.members).first())
+                } catch (e: NullPointerException) {
+                    null
+                }
             }
         }
     }

--- a/app/src/main/java/com/boosters/promise/data/promise/source/remote/PromiseBody.kt
+++ b/app/src/main/java/com/boosters/promise/data/promise/source/remote/PromiseBody.kt
@@ -11,10 +11,10 @@ data class PromiseBody(
     val destinationGeoLocation: GeoLocation = GeoLocation(),
     val date: String = "",
     val time: String = "",
-    val members: List<User> = listOf()
+    val members: List<String> = emptyList()
 )
 
-fun PromiseBody.toPromise() =
+fun PromiseBody.toPromise(members: List<User>) =
     Promise(
         promiseId = promiseId,
         title = title,

--- a/app/src/main/java/com/boosters/promise/data/promise/source/remote/PromiseRemoteDataSource.kt
+++ b/app/src/main/java/com/boosters/promise/data/promise/source/remote/PromiseRemoteDataSource.kt
@@ -5,7 +5,7 @@ import kotlinx.coroutines.flow.Flow
 
 interface PromiseRemoteDataSource {
 
-    fun addPromise(promise: PromiseBody): Flow<Boolean>
+    fun addPromise(promise: PromiseBody): Flow<Result<String>>
 
     fun removePromise(promiseId: String): Flow<Boolean>
 

--- a/app/src/main/java/com/boosters/promise/data/promise/source/remote/PromiseRemoteDataSourceImpl.kt
+++ b/app/src/main/java/com/boosters/promise/data/promise/source/remote/PromiseRemoteDataSourceImpl.kt
@@ -7,7 +7,6 @@ import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.mapNotNull
-import kotlinx.coroutines.tasks.await
 import javax.inject.Inject
 
 class PromiseRemoteDataSourceImpl @Inject constructor(

--- a/app/src/main/java/com/boosters/promise/data/promise/source/remote/PromiseRemoteDataSourceImpl.kt
+++ b/app/src/main/java/com/boosters/promise/data/promise/source/remote/PromiseRemoteDataSourceImpl.kt
@@ -57,7 +57,7 @@ class PromiseRemoteDataSourceImpl @Inject constructor(
     override fun getPromiseList(user: User, date: String): Flow<List<PromiseBody>> {
         return promiseRef
             .whereEqualTo(DATABASE_PROMISE_DATE_KEY, date)
-            .whereArrayContainsAny(DATABASE_PROMISE_MEMBERS_KEY, listOf(user.copy(userToken = "")))
+            .whereArrayContainsAny(DATABASE_PROMISE_MEMBERS_KEY, listOf(user.userCode))
             .snapshots()
             .mapNotNull {
                 it.toObjects(PromiseBody::class.java)

--- a/app/src/main/java/com/boosters/promise/data/promise/source/remote/PromiseRemoteDataSourceImpl.kt
+++ b/app/src/main/java/com/boosters/promise/data/promise/source/remote/PromiseRemoteDataSourceImpl.kt
@@ -15,7 +15,7 @@ class PromiseRemoteDataSourceImpl @Inject constructor(
 
     private val promiseRef = database.collection(DATABASE_PROMISE_REF_PATH)
 
-    override fun addPromise(promise: PromiseBody): Flow<Boolean> {
+    override fun addPromise(promise: PromiseBody): Flow<Result<String>> {
         var id = promise.promiseId
         if (promise.promiseId == "") {
             id = promiseRef.document().id
@@ -23,11 +23,11 @@ class PromiseRemoteDataSourceImpl @Inject constructor(
         return callbackFlow {
             promiseRef.document(id).set(promise.copy(promiseId = id))
                 .addOnSuccessListener {
-                    trySend(true)
+                    trySend(Result.success(id))
                     close()
                 }
                 .addOnFailureListener {
-                    trySend(false)
+                    trySend(Result.failure(it))
                     close()
                 }
             awaitClose()

--- a/app/src/main/java/com/boosters/promise/data/user/UserRepository.kt
+++ b/app/src/main/java/com/boosters/promise/data/user/UserRepository.kt
@@ -1,6 +1,5 @@
 package com.boosters.promise.data.user
 
-import com.boosters.promise.data.location.GeoLocation
 import kotlinx.coroutines.flow.Flow
 
 interface UserRepository {
@@ -12,10 +11,6 @@ interface UserRepository {
     fun getUserByName(userName: String): Flow<List<User>>
 
     fun getMyInfo(): Flow<Result<User>>
-
-    suspend fun uploadMyGeoLocation(geoLocation: GeoLocation): Result<Unit>
-
-    suspend fun resetMyGeoLocation()
 
     suspend fun getUserList(userCodeList: List<String>): Flow<List<User>>
 

--- a/app/src/main/java/com/boosters/promise/data/user/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/boosters/promise/data/user/UserRepositoryImpl.kt
@@ -1,11 +1,9 @@
 package com.boosters.promise.data.user
 
-import com.boosters.promise.data.location.GeoLocation
 import com.boosters.promise.data.user.source.local.MyInfoLocalDataSource
 import com.boosters.promise.data.user.source.remote.UserRemoteDataSource
 import com.boosters.promise.data.user.source.remote.toUser
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.mapNotNull
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -45,18 +43,6 @@ class UserRepositoryImpl @Inject constructor(
 
     override fun getMyInfo(): Flow<Result<User>> =
         myInfoLocalDataSource.getMyInfo()
-
-    override suspend fun uploadMyGeoLocation(geoLocation: GeoLocation): Result<Unit> = runCatching {
-        val user = getMyInfo().first().getOrThrow()
-        userRemoteDataSource.uploadMyGeoLocation(user.userCode, geoLocation)
-    }
-
-    override suspend fun resetMyGeoLocation() {
-        val user = getMyInfo().first().getOrNull()
-        if (user != null) {
-            userRemoteDataSource.resetMyGeoLocation(user.userCode)
-        }
-    }
 
     override suspend fun getUserList(userCodeList: List<String>): Flow<List<User>> =
         userRemoteDataSource.getUserList(userCodeList).mapNotNull { userList ->

--- a/app/src/main/java/com/boosters/promise/data/user/source/remote/UserRemoteDataSource.kt
+++ b/app/src/main/java/com/boosters/promise/data/user/source/remote/UserRemoteDataSource.kt
@@ -1,6 +1,5 @@
 package com.boosters.promise.data.user.source.remote
 
-import com.boosters.promise.data.location.GeoLocation
 import kotlinx.coroutines.flow.Flow
 
 interface UserRemoteDataSource {
@@ -8,10 +7,6 @@ interface UserRemoteDataSource {
     suspend fun requestSignUp(userName: String): Result<UserBody>
 
     fun getUser(userCode: String): Flow<UserBody>
-
-    suspend fun uploadMyGeoLocation(userCode: String, geoLocation: GeoLocation?): Result<Unit>
-
-    suspend fun resetMyGeoLocation(userCode: String)
 
     suspend fun getUserList(userCodeList: List<String>): Flow<List<UserBody>>
 

--- a/app/src/main/java/com/boosters/promise/data/user/source/remote/UserRemoteDataSourceImpl.kt
+++ b/app/src/main/java/com/boosters/promise/data/user/source/remote/UserRemoteDataSourceImpl.kt
@@ -1,6 +1,5 @@
 package com.boosters.promise.data.user.source.remote
 
-import com.boosters.promise.data.location.GeoLocation
 import com.boosters.promise.data.network.NetworkConnectionUtil
 import com.boosters.promise.data.user.di.UserModule
 import com.google.firebase.firestore.CollectionReference
@@ -41,19 +40,6 @@ class UserRemoteDataSourceImpl @Inject constructor(
             it.toObject(UserBody::class.java)
         }
 
-    override suspend fun uploadMyGeoLocation(userCode: String, geoLocation: GeoLocation?): Result<Unit> = runCatching {
-        networkConnectionUtil.checkNetworkOnline()
-
-        userCollectionReference.document(userCode)
-            .update(GEO_LOCATION_FIELD, geoLocation)
-            .addOnSuccessListener { Result.success(Unit) }
-            .addOnFailureListener { Result.failure<Unit>(it) }
-    }
-
-    override suspend fun resetMyGeoLocation(userCode: String) {
-        uploadMyGeoLocation(userCode, null)
-    }
-
     override suspend fun getUserList(userCodeList: List<String>): Flow<List<UserBody>> =
         userCollectionReference.whereIn(USER_CODE_KEY, userCodeList).snapshots().mapNotNull {
             it.toObjects(UserBody::class.java)
@@ -68,7 +54,6 @@ class UserRemoteDataSourceImpl @Inject constructor(
         private const val USER_CODE_LENGTH = 6
         private const val USER_CODE_KEY = "userCode"
         private const val USER_NAME_KEY = "userName"
-        private const val GEO_LOCATION_FIELD = "geoLocation"
     }
 
 }

--- a/app/src/main/java/com/boosters/promise/service/locationupload/LocationUploadForegroundService.kt
+++ b/app/src/main/java/com/boosters/promise/service/locationupload/LocationUploadForegroundService.kt
@@ -10,7 +10,6 @@ import androidx.lifecycle.LifecycleService
 import androidx.lifecycle.lifecycleScope
 import com.boosters.promise.R
 import com.boosters.promise.data.location.LocationRepository
-import com.boosters.promise.data.user.UserRepository
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
@@ -21,9 +20,6 @@ class LocationUploadForegroundService : LifecycleService(), LocationUploadServic
 
     @Inject
     lateinit var locationRepository: LocationRepository
-
-    @Inject
-    lateinit var userRepository: UserRepository
 
     private val locationUploadServiceBinder = LocationUploadServiceBinder(this)
 
@@ -54,7 +50,7 @@ class LocationUploadForegroundService : LifecycleService(), LocationUploadServic
     override fun onDestroy() {
         super.onDestroy()
         alarmHandler.looper.quit()
-        lifecycleScope.launch { userRepository.resetMyGeoLocation() }
+        lifecycleScope.launch { locationRepository.resetMyGeoLocation() }
         locationRepository.stopLocationUpdates()
     }
 
@@ -84,7 +80,7 @@ class LocationUploadForegroundService : LifecycleService(), LocationUploadServic
         lifecycleScope.launch {
             locationRepository.lastGeoLocation.collectLatest { geoLocation ->
                 if (geoLocation != null) {
-                    userRepository.uploadMyGeoLocation(geoLocation)
+                    locationRepository.uploadMyGeoLocation(geoLocation)
                 }
             }
         }

--- a/app/src/main/java/com/boosters/promise/ui/detail/PromiseDetailActivity.kt
+++ b/app/src/main/java/com/boosters/promise/ui/detail/PromiseDetailActivity.kt
@@ -33,6 +33,7 @@ import android.content.pm.PackageManager
 import android.graphics.Color
 import com.boosters.promise.service.locationupload.LocationUploadForegroundService
 import com.boosters.promise.service.locationupload.LocationUploadServiceConnection
+import kotlinx.coroutines.delay
 
 @AndroidEntryPoint
 class PromiseDetailActivity : AppCompatActivity(), OnMapReadyCallback {
@@ -141,6 +142,8 @@ class PromiseDetailActivity : AppCompatActivity(), OnMapReadyCallback {
 
     private fun setObserver(map: NaverMap) {
         lifecycleScope.launch {
+            delay(1_000)
+            // TODO: 비동기 버그 해결하기 #110
             repeatOnLifecycle(Lifecycle.State.STARTED) {
                 promiseDetailViewModel.promiseInfo.collectLatest { promise ->
                     launch {

--- a/app/src/main/java/com/boosters/promise/ui/detail/PromiseDetailActivity.kt
+++ b/app/src/main/java/com/boosters/promise/ui/detail/PromiseDetailActivity.kt
@@ -31,8 +31,6 @@ import kotlinx.coroutines.launch
 import android.Manifest.permission
 import android.content.pm.PackageManager
 import android.graphics.Color
-import com.boosters.promise.service.locationupload.LocationUploadForegroundService
-import com.boosters.promise.service.locationupload.LocationUploadServiceConnection
 
 @AndroidEntryPoint
 class PromiseDetailActivity : AppCompatActivity(), OnMapReadyCallback {
@@ -48,22 +46,15 @@ class PromiseDetailActivity : AppCompatActivity(), OnMapReadyCallback {
         permission.ACCESS_FINE_LOCATION
     )
     private val requestLocationPermissionLauncher =
-        registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { permissions ->
-            val locationPermissionCheckResult = locationPermissions.map {
-                permissions.getOrDefault(it, false)
-            }
-            if (isLocationPermissionGranted(locationPermissionCheckResult)) {
-                startLocationUploadService()
-            }
-        }
-
-    private val locationUploadServiceConnection = LocationUploadServiceConnection()
+        registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
         binding = DataBindingUtil.setContentView(this, R.layout.activity_promise_detail)
         setBinding()
+
+        if (checkLocationPermission().not()) requestPermission()
 
         initMap()
         setPromiseInfo()
@@ -81,16 +72,6 @@ class PromiseDetailActivity : AppCompatActivity(), OnMapReadyCallback {
                 showStateSnackbar(R.string.promiseDetail_delete_ask)
             }
         }
-    }
-
-    override fun onStart() {
-        super.onStart()
-        if (checkLocationPermission()) startLocationUploadService() else requestPermission()
-    }
-
-    override fun onStop() {
-        super.onStop()
-        unbindService(locationUploadServiceConnection)
     }
 
     override fun onMapReady(map: NaverMap) {
@@ -177,10 +158,10 @@ class PromiseDetailActivity : AppCompatActivity(), OnMapReadyCallback {
         lifecycleScope.launch {
             promiseDetailViewModel.memberLocations.collectLatest {
                 it?.forEachIndexed { idx, memberLocation ->
-                    if (memberLocation != null) {
+                    if (memberLocation?.geoLocation != null) {
                         promiseDetailViewModel.memberMarkers[idx].apply {
                             iconTintColor = Color.BLUE
-                            position = memberLocation.toLatLng()
+                            position = memberLocation.geoLocation.toLatLng()
                             this.map = map
                         }
                     }
@@ -209,13 +190,6 @@ class PromiseDetailActivity : AppCompatActivity(), OnMapReadyCallback {
             .show()
     }
 
-    private fun startLocationUploadService() {
-        val intent = Intent(this, LocationUploadForegroundService::class.java).apply {
-            putExtra(LocationUploadForegroundService.END_TIME_KEY, DEFAULT_LOCATION_UPLOAD_END_TIME)
-        }
-        bindService(intent, locationUploadServiceConnection, BIND_AUTO_CREATE)
-    }
-
     private fun checkLocationPermission(): Boolean {
         val locationPermissionCheckResult = locationPermissions.map {
             checkSelfPermission(it) == PackageManager.PERMISSION_GRANTED
@@ -235,7 +209,6 @@ class PromiseDetailActivity : AppCompatActivity(), OnMapReadyCallback {
 
     companion object {
         const val PROMISE_ID_KEY = "promiseId"
-        private const val DEFAULT_LOCATION_UPLOAD_END_TIME = 90_000L
     }
 
 }

--- a/app/src/main/java/com/boosters/promise/ui/detail/PromiseDetailActivity.kt
+++ b/app/src/main/java/com/boosters/promise/ui/detail/PromiseDetailActivity.kt
@@ -33,7 +33,6 @@ import android.content.pm.PackageManager
 import android.graphics.Color
 import com.boosters.promise.service.locationupload.LocationUploadForegroundService
 import com.boosters.promise.service.locationupload.LocationUploadServiceConnection
-import kotlinx.coroutines.delay
 
 @AndroidEntryPoint
 class PromiseDetailActivity : AppCompatActivity(), OnMapReadyCallback {
@@ -142,20 +141,20 @@ class PromiseDetailActivity : AppCompatActivity(), OnMapReadyCallback {
 
     private fun setObserver(map: NaverMap) {
         lifecycleScope.launch {
-            delay(1_000)
-            // TODO: 비동기 버그 해결하기 #110
             repeatOnLifecycle(Lifecycle.State.STARTED) {
                 promiseDetailViewModel.promiseInfo.collectLatest { promise ->
                     launch {
-                        promiseMemberAdapter.submitList(promise.members)
+                        promiseMemberAdapter.submitList(promise?.members)
                     }
 
                     launch {
-                        val destinationLocation = promise.destinationGeoLocation.toLatLng()
+                        if (promise != null) {
+                            val destinationLocation = promise.destinationGeoLocation.toLatLng()
 
-                        moveCameraToDestination(destinationLocation, map)
-                        markDestinationOnMap(destinationLocation, map)
-                        markUserLocationOnMap(map)
+                            moveCameraToDestination(destinationLocation, map)
+                            markDestinationOnMap(destinationLocation, map)
+                            markUserLocationOnMap(map)
+                        }
                     }
                 }
             }
@@ -177,7 +176,7 @@ class PromiseDetailActivity : AppCompatActivity(), OnMapReadyCallback {
     private suspend fun markUserLocationOnMap(map: NaverMap) {
         lifecycleScope.launch {
             promiseDetailViewModel.memberLocations.collectLatest {
-                it.forEachIndexed { idx, memberLocation ->
+                it?.forEachIndexed { idx, memberLocation ->
                     if (memberLocation != null) {
                         promiseDetailViewModel.memberMarkers[idx].apply {
                             iconTintColor = Color.BLUE

--- a/app/src/main/java/com/boosters/promise/ui/detail/PromiseDetailViewModel.kt
+++ b/app/src/main/java/com/boosters/promise/ui/detail/PromiseDetailViewModel.kt
@@ -6,9 +6,11 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.boosters.promise.data.location.LocationRepository
 import com.boosters.promise.data.location.UserGeoLocation
+import com.boosters.promise.data.member.Member
 import com.boosters.promise.data.member.MemberRepository
 import com.boosters.promise.data.promise.Promise
 import com.boosters.promise.data.promise.PromiseRepository
+import com.boosters.promise.data.user.UserRepository
 import com.naver.maps.map.overlay.Marker
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -20,6 +22,7 @@ import javax.inject.Inject
 @HiltViewModel
 class PromiseDetailViewModel @Inject constructor(
     private val promiseRepository: PromiseRepository,
+    private val userRepository: UserRepository,
     private val memberRepository: MemberRepository,
     private val locationRepository: LocationRepository
 ) : ViewModel() {
@@ -71,6 +74,28 @@ class PromiseDetailViewModel @Inject constructor(
                         cancel()
                     }
                 }
+            }
+        }
+    }
+
+    fun updateLocationSharingPermission(isAcceptLocationSharing: Boolean) {
+        viewModelScope.launch {
+            try {
+                val userCode = userRepository.getMyInfo().first().getOrElse { throw IllegalStateException() }.userCode
+                promiseInfo.collectLatest { promise ->
+                    if (promise != null) {
+                        memberRepository.updateIsAcceptLocation(
+                            Member(
+                                promiseId = promise.promiseId,
+                                userCode = userCode,
+                                isAcceptLocation = isAcceptLocationSharing
+                            )
+                        )
+                        cancel()
+                    }
+                }
+            } catch (e: IllegalStateException) {
+                cancel()
             }
         }
     }

--- a/app/src/main/java/com/boosters/promise/ui/detail/PromiseDetailViewModel.kt
+++ b/app/src/main/java/com/boosters/promise/ui/detail/PromiseDetailViewModel.kt
@@ -4,12 +4,14 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.boosters.promise.data.location.GeoLocation
 import com.boosters.promise.data.promise.Promise
 import com.boosters.promise.data.promise.PromiseRepository
 import com.boosters.promise.data.user.UserRepository
 import com.naver.maps.map.overlay.Marker
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -20,8 +22,8 @@ class PromiseDetailViewModel @Inject constructor(
     private val userRepository: UserRepository
 ) : ViewModel() {
 
-    private val _promiseInfo = MutableStateFlow(Promise())
-    val promiseInfo: StateFlow<Promise> get() = _promiseInfo.asStateFlow()
+    private val _promiseInfo = MutableStateFlow<Promise?>(null)
+    val promiseInfo: StateFlow<Promise?> get() = _promiseInfo.asStateFlow()
 
     private val _isDeleted = MutableLiveData<Boolean>()
     val isDeleted: LiveData<Boolean> = _isDeleted
@@ -29,24 +31,36 @@ class PromiseDetailViewModel @Inject constructor(
     lateinit var memberMarkers: List<Marker>
 
     @OptIn(ExperimentalCoroutinesApi::class)
-    val memberLocations = promiseInfo.flatMapLatest { promise ->
-        userRepository.getUserList(promise.members.map { user -> user.userCode }).map { members ->
-            members.map { member -> member.geoLocation }
+    val memberLocations: Flow<List<GeoLocation?>?> = promiseInfo.flatMapLatest { promise ->
+        if (promise != null) {
+            userRepository.getUserList(promise.members.map { user -> user.userCode }).map { members ->
+                members.map { member -> member.geoLocation }
+            }
+        } else {
+            flow { emit(null) }
         }
     }
 
     fun setPromiseInfo(promiseId: String) {
         viewModelScope.launch {
             _promiseInfo.value = promiseRepository.getPromise(promiseId).first().copy()
-            memberMarkers = List(_promiseInfo.value.members.size) { Marker() }
+            promiseInfo.collectLatest { promise ->
+                if (promise != null) {
+                    memberMarkers = List(promise.members.size) { Marker() }
+                    cancel()
+                }
+            }
         }
     }
 
     fun removePromise() {
         viewModelScope.launch {
-            _promiseInfo.value.let {
-                promiseRepository.removePromise(it.promiseId).collectLatest { isDeleted ->
-                    _isDeleted.value = isDeleted
+            promiseInfo.value.let { promise ->
+                if (promise != null) {
+                    promiseRepository.removePromise(promise.promiseId).collectLatest { isDeleted ->
+                        _isDeleted.value = isDeleted
+                        cancel()
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/boosters/promise/ui/promisesetting/PromiseSettingActivity.kt
+++ b/app/src/main/java/com/boosters/promise/ui/promisesetting/PromiseSettingActivity.kt
@@ -1,7 +1,6 @@
 package com.boosters.promise.ui.promisesetting
 
 import android.content.Intent
-import android.os.Build
 import android.os.Build.VERSION
 import android.os.Bundle
 import android.text.format.DateFormat

--- a/app/src/main/res/layout/activity_promise_detail.xml
+++ b/app/src/main/res/layout/activity_promise_detail.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout xmlns:tools="http://schemas.android.com/tools">
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <data>
 
@@ -8,8 +10,7 @@
             type="com.boosters.promise.ui.detail.PromiseDetailViewModel" />
     </data>
 
-    <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:app="http://schemas.android.com/apk/res-auto"
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         tools:context=".ui.detail.PromiseDetailActivity">
@@ -81,7 +82,7 @@
             android:layout_marginStart="10dp"
             android:text="@{viewModel.promiseInfo.destinationName}"
             app:layout_constraintBottom_toBottomOf="@+id/textView_promiseDetail_location"
-            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintEnd_toStartOf="@id/switch_promiseDetail_locationSharing"
             app:layout_constraintStart_toEndOf="@+id/textView_promiseDetail_location"
             app:layout_constraintTop_toTopOf="@+id/textView_promiseDetail_location"
             tools:text="홍대입구역 90번 출구" />
@@ -108,10 +109,38 @@
             android:layout_marginStart="10dp"
             android:text="@{@string/promiseDetail_date_format(viewModel.promiseInfo.date, viewModel.promiseInfo.time)}"
             app:layout_constraintBottom_toBottomOf="@+id/textView_promiseDetail_date"
-            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintEnd_toStartOf="@id/switch_promiseDetail_locationSharing"
             app:layout_constraintStart_toEndOf="@+id/textView_promiseDetail_date"
             app:layout_constraintTop_toTopOf="@+id/textView_promiseDetail_date"
             tools:text="2022/11/23 17:00" />
+
+        <androidx.constraintlayout.widget.Barrier
+            android:id="@+id/barrier_promiseDetail_promiseDataAndLocationEnd"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:barrierDirection="end"
+            app:constraint_referenced_ids="textView_promiseDetail_promiseLocation, textView_promiseDetail_promiseDate" />
+
+        <androidx.constraintlayout.widget.Barrier
+            android:id="@+id/barrier_promiseDetail_dateBottom"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:barrierDirection="bottom"
+            app:constraint_referenced_ids="textView_promiseDetail_date, textView_promiseDetail_promiseDate" />
+
+        <com.google.android.material.switchmaterial.SwitchMaterial
+            android:id="@+id/switch_promiseDetail_locationSharing"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/promiseDetail_location_sharing_permission"
+            android:checked="@={viewModel.isAcceptLocationSharing}"
+            android:onCheckedChanged="@{(buttonView, isChecked) -> viewModel.updateLocationSharingPermission(isChecked)}"
+            app:layout_constraintBottom_toTopOf="@id/barrier_promiseDetail_dateBottom"
+            app:layout_constraintEnd_toEndOf="@id/guideline_promiseDetail_right"
+            app:layout_constraintHorizontal_bias="1.0"
+            app:layout_constraintStart_toEndOf="@id/barrier_promiseDetail_promiseDataAndLocationEnd"
+            app:layout_constraintTop_toBottomOf="@id/textView_promiseDetail_promiseTitle"
+            app:layout_constraintVertical_bias="1.0" />
 
         <androidx.fragment.app.FragmentContainerView
             android:id="@+id/fragment_promiseDetail_map"
@@ -124,9 +153,9 @@
             app:layout_constraintDimensionRatio="1:1"
             app:layout_constraintEnd_toStartOf="@+id/guideline_promiseDetail_right"
             app:layout_constraintStart_toStartOf="@+id/guideline_promiseDetail_left"
-            app:layout_constraintTop_toBottomOf="@+id/textView_promiseDetail_date"
+            app:layout_constraintTop_toBottomOf="@+id/barrier_promiseDetail_dateBottom"
             tools:background="@color/azure_radiance"
-            tools:layout="@layout/activity_promise_detail" />
+            tools:layout="@layout/activity_start" />
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/recyclerView_promiseDetail_memberList"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -74,6 +74,7 @@
     <string name="promiseDetail_delete_ask">삭제하시겠습니까?</string>
     <string name="promiseDetail_dialog_yes">YES</string>
     <string name="promiseDetail_dialog_no">NO</string>
+    <string name="promiseDetail_location_sharing_permission">위치 공유</string>
 
     <!-- LocationService 알림 -->
     <string name="locationService_notification_title">위치 공유중입니다.</string>


### PR DESCRIPTION
## Issue
#100
resolved #106

## Changed
- Member 구현
- UserGeoLocation 구현
- 약속 별 위치 공유 여부, firestore, datastore에 저장
- 위치 공유 스위치 추가
- 상세화면에서 위치공유 서비스 시작하던거 삭제
    - 상세 화면에 들어가면 치리 까다로워짐
- #100 임시 조치