### PR TITLE
삭제된 약속 삭제 알림으로 접속 시 버그 해결

### DIFF
--- a/app/src/main/java/com/boosters/promise/data/promise/PromiseRepository.kt
+++ b/app/src/main/java/com/boosters/promise/data/promise/PromiseRepository.kt
@@ -11,7 +11,7 @@ interface PromiseRepository {
 
     fun removePromise(promiseId: String): Flow<Boolean>
 
-    fun getPromise(promiseId: String): Flow<Promise>
+    fun getPromise(promiseId: String): Flow<Promise?>
 
     fun getPromiseList(user: User): Flow<List<Promise>>
 

--- a/app/src/main/java/com/boosters/promise/data/promise/PromiseRepositoryImpl.kt
+++ b/app/src/main/java/com/boosters/promise/data/promise/PromiseRepositoryImpl.kt
@@ -46,9 +46,9 @@ class PromiseRepositoryImpl @Inject constructor(
         }
     }
 
-    override fun getPromise(promiseId: String): Flow<Promise> {
-        return promiseRemoteDataSource.getPromise(promiseId).mapNotNull { promiseBody ->
-            promiseBody.toPromise(
+    override fun getPromise(promiseId: String): Flow<Promise?> {
+        return promiseRemoteDataSource.getPromise(promiseId).map { promiseBody ->
+            promiseBody?.toPromise(
                 promiseBody.members.map {
                     userRepository.getUser(it).first()
                 }

--- a/app/src/main/java/com/boosters/promise/data/promise/source/remote/PromiseRemoteDataSource.kt
+++ b/app/src/main/java/com/boosters/promise/data/promise/source/remote/PromiseRemoteDataSource.kt
@@ -9,7 +9,7 @@ interface PromiseRemoteDataSource {
 
     fun removePromise(promiseId: String): Flow<Boolean>
 
-    fun getPromise(promiseId: String): Flow<PromiseBody>
+    fun getPromise(promiseId: String): Flow<PromiseBody?>
 
     fun getPromiseList(user: User): Flow<List<PromiseBody>>
 

--- a/app/src/main/java/com/boosters/promise/data/promise/source/remote/PromiseRemoteDataSourceImpl.kt
+++ b/app/src/main/java/com/boosters/promise/data/promise/source/remote/PromiseRemoteDataSourceImpl.kt
@@ -6,6 +6,7 @@ import com.google.firebase.firestore.ktx.snapshots
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapNotNull
 import javax.inject.Inject
 
@@ -49,8 +50,8 @@ class PromiseRemoteDataSourceImpl @Inject constructor(
         }
     }
 
-    override fun getPromise(promiseId: String): Flow<PromiseBody> =
-        promiseRef.document(promiseId).snapshots().mapNotNull {
+    override fun getPromise(promiseId: String): Flow<PromiseBody?> =
+        promiseRef.document(promiseId).snapshots().map {
             it.toObject(PromiseBody::class.java)
         }
 

--- a/app/src/main/java/com/boosters/promise/ui/detail/PromiseDetailActivity.kt
+++ b/app/src/main/java/com/boosters/promise/ui/detail/PromiseDetailActivity.kt
@@ -8,7 +8,6 @@ import android.view.Menu
 import android.view.MenuItem
 import android.view.View
 import android.widget.CompoundButton.OnCheckedChangeListener
-import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.appcompat.app.AlertDialog
@@ -371,8 +370,13 @@ class PromiseDetailActivity : AppCompatActivity(), OnMapReadyCallback {
     private fun setPromiseFailUiStateObserver() {
         lifecycleScope.launch {
             promiseDetailViewModel.promiseFailUiState.collectLatest { promiseFailUiState ->
-                Toast.makeText(applicationContext, promiseFailUiState.messageResId, Toast.LENGTH_SHORT).show()
-                if (promiseFailUiState.isActivityFinish) finish()
+                AlertDialog.Builder(this@PromiseDetailActivity)
+                    .setMessage(promiseFailUiState.messageResId)
+                    .setNeutralButton(R.string.ok) { _, _ ->
+                        if (promiseFailUiState.isActivityFinish) finish()
+                    }
+                    .create()
+                    .show()
             }
         }
     }

--- a/app/src/main/java/com/boosters/promise/ui/detail/PromiseDetailActivity.kt
+++ b/app/src/main/java/com/boosters/promise/ui/detail/PromiseDetailActivity.kt
@@ -8,6 +8,7 @@ import android.view.Menu
 import android.view.MenuItem
 import android.view.View
 import android.widget.CompoundButton.OnCheckedChangeListener
+import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.appcompat.app.AlertDialog
@@ -89,6 +90,7 @@ class PromiseDetailActivity : AppCompatActivity(), OnMapReadyCallback {
         super.onCreate(savedInstanceState)
         binding = DataBindingUtil.setContentView(this, R.layout.activity_promise_detail)
 
+        setPromiseFailUiStateObserver()
         loadingDialog = LoadingDialog(this)
         loadingDialog.show()
 
@@ -119,6 +121,11 @@ class PromiseDetailActivity : AppCompatActivity(), OnMapReadyCallback {
     override fun onStop() {
         super.onStop()
         if (promiseDetailViewModel.isStartLocationUpdates.value) promiseDetailViewModel.stopLocationUpdates()
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        loadingDialog.dismiss()
     }
 
     override fun onMapReady(map: NaverMap) {
@@ -357,6 +364,15 @@ class PromiseDetailActivity : AppCompatActivity(), OnMapReadyCallback {
                     Snackbar.make(binding.root, R.string.signUp_networkError, Snackbar.LENGTH_SHORT)
                         .show()
                 }
+            }
+        }
+    }
+
+    private fun setPromiseFailUiStateObserver() {
+        lifecycleScope.launch {
+            promiseDetailViewModel.promiseFailUiState.collectLatest { promiseFailUiState ->
+                Toast.makeText(applicationContext, promiseFailUiState.messageResId, Toast.LENGTH_SHORT).show()
+                if (promiseFailUiState.isActivityFinish) finish()
             }
         }
     }

--- a/app/src/main/java/com/boosters/promise/ui/detail/PromiseDetailActivity.kt
+++ b/app/src/main/java/com/boosters/promise/ui/detail/PromiseDetailActivity.kt
@@ -89,10 +89,11 @@ class PromiseDetailActivity : AppCompatActivity(), OnMapReadyCallback {
         super.onCreate(savedInstanceState)
         binding = DataBindingUtil.setContentView(this, R.layout.activity_promise_detail)
 
+        loadingDialog = LoadingDialog(this)
         loadingDialog.show()
 
         setBinding()
-
+        setDestinationButtonClickListener()
         sendPromiseUploadInfoToReceiver()
 
         initMap()
@@ -159,8 +160,6 @@ class PromiseDetailActivity : AppCompatActivity(), OnMapReadyCallback {
     private fun setBinding() {
         binding.lifecycleOwner = this
         binding.recyclerViewPromiseDetailMemberList.adapter = promiseMemberAdapter
-
-        loadingDialog = LoadingDialog(this)
         lifecycleScope.launch {
             launch {
                 promiseDetailViewModel.promise.collectLatest {
@@ -202,22 +201,22 @@ class PromiseDetailActivity : AppCompatActivity(), OnMapReadyCallback {
         }
 
         promiseMemberAdapter.setOnItemClickListener(object :
-            PromiseMemberAdapter.OnItemClickListener {
-            override fun onItemClick(memberUiModel: MemberUiModel) {
-                lifecycleScope.launch {
-                    promiseDetailViewModel.userGeoLocations.first().let { userGeoLocation ->
-                        val selectedMemberLocation =
-                            userGeoLocation.find { it.userCode == memberUiModel.userCode }?.geoLocation
+                PromiseMemberAdapter.OnItemClickListener {
+                override fun onItemClick(memberUiModel: MemberUiModel) {
+                    lifecycleScope.launch {
+                        promiseDetailViewModel.userGeoLocations.first().let { userGeoLocation ->
+                            val selectedMemberLocation =
+                                userGeoLocation.find { it.userCode == memberUiModel.userCode }?.geoLocation
 
-                        if (selectedMemberLocation != null) {
-                            mapManager.moveToLocation(selectedMemberLocation)
-                        } else {
-                            showStateSnackbar(R.string.promiseDetail_memberLocation_null)
+                            if (selectedMemberLocation != null) {
+                                mapManager.moveToLocation(selectedMemberLocation)
+                            } else {
+                                showStateSnackbar(R.string.promiseDetail_memberLocation_null)
+                            }
                         }
                     }
                 }
-            }
-        })
+            })
     }
 
     private fun setObserver() {

--- a/app/src/main/java/com/boosters/promise/ui/detail/model/PromiseFailUiState.kt
+++ b/app/src/main/java/com/boosters/promise/ui/detail/model/PromiseFailUiState.kt
@@ -1,0 +1,8 @@
+package com.boosters.promise.ui.detail.model
+
+import androidx.annotation.StringRes
+
+data class PromiseFailUiState(
+    @StringRes val messageResId: Int,
+    val isActivityFinish: Boolean
+)

--- a/app/src/main/java/com/boosters/promise/ui/invite/InviteActivity.kt
+++ b/app/src/main/java/com/boosters/promise/ui/invite/InviteActivity.kt
@@ -69,12 +69,13 @@ class InviteActivity : AppCompatActivity() {
     }
 
     private fun setMemberItemClickListener() {
-        inviteMemberAdapter.setOnItemClickListener(object :
-            InviteMemberAdapter.OnItemClickListener {
-            override fun onItemClick(user: UserUiModel) {
-                inviteViewModel.removeMemberItems(user)
+        inviteMemberAdapter.setOnItemClickListener(
+            object : InviteMemberAdapter.OnItemClickListener {
+                override fun onItemClick(user: UserUiModel) {
+                    inviteViewModel.removeMemberItems(user)
+                }
             }
-        })
+        )
     }
 
     private fun setConfirmButtonClickListener() {

--- a/app/src/main/java/com/boosters/promise/ui/promisecalendar/PromiseCalendarActivity.kt
+++ b/app/src/main/java/com/boosters/promise/ui/promisecalendar/PromiseCalendarActivity.kt
@@ -121,14 +121,15 @@ class PromiseCalendarActivity : AppCompatActivity() {
             }
         }
 
-        promiseDailyListAdapter.setOnItemClickListener(object :
-            PromiseDailyListAdapter.OnItemClickListener {
-            override fun onItemClick(promise: Promise) {
-                val intent = Intent(this@PromiseCalendarActivity, PromiseDetailActivity::class.java)
-                intent.putExtra(PROMISE_ID_KEY, promise.promiseId)
-                startActivity(intent)
+        promiseDailyListAdapter.setOnItemClickListener(
+            object : PromiseDailyListAdapter.OnItemClickListener {
+                override fun onItemClick(promise: Promise) {
+                    val intent = Intent(this@PromiseCalendarActivity, PromiseDetailActivity::class.java)
+                    intent.putExtra(PROMISE_ID_KEY, promise.promiseId)
+                    startActivity(intent)
+                }
             }
-        })
+        )
     }
 
     private fun bindCalendarView() {

--- a/app/src/main/res/layout/activity_promise_detail.xml
+++ b/app/src/main/res/layout/activity_promise_detail.xml
@@ -122,7 +122,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="10dp"
-                android:text="@{@string/promiseDetail_date_format(promise.date, promise.time)}"
+                android:text='@{promise.date == null ? "" : @string/promiseDetail_date_format(promise.date, promise.time)}'
                 app:layout_constraintBottom_toBottomOf="@+id/textView_promiseDetail_date"
                 app:layout_constraintEnd_toStartOf="@id/switch_promiseDetail_locationSharing"
                 app:layout_constraintStart_toEndOf="@+id/textView_promiseDetail_date"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -85,6 +85,7 @@
     <string name="promiseDetail_location_sharing_permission">위치 공유</string>
     <string name="promiseDetail_myLocation">내 위치</string>
     <string name="promiseDetail_require_location_permission">위치 권한이 필요합니다.</string>
+    <string name="promiseDetail_promise_load_exception">약속이 삭제되었습니다.</string>
 
     <!-- LocationService 알림 -->
     <string name="locationService_notification_title">위치 공유중입니다.</string>


### PR DESCRIPTION
## Issues
resolved #166
resolved #170

## Changes
- 약속 알림이 남아있는 상태에서 약속이 삭제되었거나 약속 멤버에서 나왔을때, 남아있는 약속알림으로 해당 약속 상세화면으로 진입할때 생기는 버그 해결
- 약속 상세화면에서 약속이 삭제되었을때도 약속 삭제 알림이 나온다.
- 약속 상세화면 로딩 중에 날짜가 null로 표시되는 문제 해결

## ScreenShots
![image](https://user-images.githubusercontent.com/68229193/206382304-3fa1bb3b-16ce-4312-a615-92c22ce9ee1a.png)
